### PR TITLE
Reorder DSM to lower left

### DIFF
--- a/html/dsm.js
+++ b/html/dsm.js
@@ -1,0 +1,63 @@
+import { alg as graphAlg } from 'graphlib'
+import flatMap from 'lodash.flatmap'
+import _sortBy from 'lodash.sortby'
+import flow from 'lodash.flow'
+import { graphFromAdjacency, condense } from './graph'
+
+const sortBy = iteratees => collection => _sortBy(collection, iteratees)
+
+const deps = (fromNode, toNode) => {
+  if (fromNode === toNode) return NaN
+  let result = 0
+  for (const dep of fromNode.allDependencies()) {
+    if (dep.isChildOf(toNode)) result += 1
+  }
+  return result
+}
+
+export default function createLowerLeftDsm(nodes) {
+  const dependencyMatrix = nodes.map(y => nodes.map(x => deps(x, y)))
+  const dependencyGraph = graphFromAdjacency(dependencyMatrix, nodes.map(x => x.toString()))
+  const { condensedGraph, condensationToGraph, sccs } = condense(dependencyGraph)
+  const condensedOrder = graphAlg.topsort(condensedGraph)
+  const orderedClusters = condensedOrder.map(x => condensationToGraph[x])
+  const isMemberOf = array => candidate => array.indexOf(candidate) >= 0
+  const contains = candidate => array => array.indexOf(candidate) >= 0
+  const orderedClustersWithCounts = orderedClusters.map(cluster => cluster.map(nodeId => ({
+    id: nodeId,
+    inCount: dependencyGraph
+      .predecessors(nodeId)
+      .filter(isMemberOf(cluster))
+      .length,
+    outCount: dependencyGraph
+      .successors(nodeId)
+      .filter(isMemberOf(cluster))
+      .length,
+  })))
+  const decreasingOutCount = i => -i.outCount
+  const inCount = i => i.inCount
+  const sortToLowerLeft = sortBy([inCount, decreasingOutCount])
+  const order = flatMap(orderedClustersWithCounts, flow(
+    sortToLowerLeft,
+    cluster => cluster.map(i => i.id),
+  ))
+  const sccOfNode = node => sccs.find(contains(node.toString()))
+
+  const sortedNodes = sortBy(node => order.indexOf(node.toString()))(nodes)
+  const matrix = sortedNodes.map((y) => {
+    const sccOfY = sccOfNode(y)
+
+    return sortedNodes.map((x) => {
+      const isScc = sccOfY.length > 1 && sccOfNode(x) === sccOfY
+      return {
+        deps: deps(x, y),
+        isScc,
+      }
+    })
+  })
+
+  return {
+    matrix,
+    dsmNodes: sortedNodes,
+  }
+}

--- a/html/graph.js
+++ b/html/graph.js
@@ -1,0 +1,66 @@
+import assert from 'assert'
+import { Graph, json as graphJson, alg as graphAlg } from 'graphlib'
+import sortBy from 'lodash.sortby'
+
+export function graphFromAdjacency(matrix, ids) {
+  assert(matrix.length === ids.length, 'mismatch between matrix and ids')
+
+  const graph = new Graph({ directed: true })
+  ids.forEach((id) => { graph.setNode(id) })
+
+  matrix.forEach((row, toIndex) => {
+    row
+      .forEach((col, fromIndex) => {
+        if (col > 0) {
+          graph.setEdge(ids[fromIndex], ids[toIndex])
+        }
+      })
+  })
+
+  return graph
+}
+
+function getCanonicalId(array) {
+  const sortedArray = sortBy(array)
+  return sortedArray.join()
+}
+
+const edgeToCondensation = graphToCondensation => ({ v, w }) => ({
+  v: graphToCondensation[v],
+  w: graphToCondensation[w],
+})
+
+const isNoLoop = ({ v, w }) => v !== w
+
+export function condense(graph) {
+  const sccs = graphAlg.tarjan(graph)
+  const condensedGraph = new Graph({ directed: true })
+  const graphToCondensation = {}
+  const condensationToGraph = {}
+
+  sccs.forEach((scc) => {
+    const canonicalId = getCanonicalId(scc)
+    scc.forEach((x) => { graphToCondensation[x] = canonicalId })
+    condensationToGraph[canonicalId] = scc
+    condensedGraph.setNode(canonicalId)
+  })
+
+  graph
+    .edges()
+    .map(edgeToCondensation(graphToCondensation))
+    .filter(isNoLoop)
+    .forEach((edge) => {
+      condensedGraph.setEdge(edge)
+    })
+
+  return {
+    condensedGraph,
+    graphToCondensation,
+    condensationToGraph,
+    sccs,
+  }
+}
+
+export function toJson(graph) {
+  return graphJson.write(graph)
+}

--- a/package.json
+++ b/package.json
@@ -38,6 +38,10 @@
   "dependencies": {
     "babel-polyfill": "^6.23.0",
     "d3": "^4.6.0",
-    "d3-scale-chromatic": "^1.1.1"
+    "d3-scale-chromatic": "^1.1.1",
+    "graphlib": "^2.1.1",
+    "lodash.flatmap": "^4.5.0",
+    "lodash.flow": "^3.5.0",
+    "lodash.sortby": "^4.7.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2130,6 +2130,12 @@ graceful-fs@~1.2.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
+graphlib@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/graphlib/-/graphlib-2.1.1.tgz#42352c52ba2f4d035cb566eb91f7395f76ebc951"
+  dependencies:
+    lodash "^4.11.1"
+
 gulp-babel@^6.1.2:
   version "6.1.2"
   resolved "https://registry.yarnpkg.com/gulp-babel/-/gulp-babel-6.1.2.tgz#7c0176e4ba3f244c60588a0c4b320a45d1adefce"
@@ -2828,9 +2834,17 @@ lodash.escape@^3.0.0:
   dependencies:
     lodash._root "^3.0.0"
 
+lodash.flatmap@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatmap/-/lodash.flatmap-4.5.0.tgz#ef8cbf408f6e48268663345305c6acc0b778702e"
+
 lodash.flatten@^4.2.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
+
+lodash.flow@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.flow/-/lodash.flow-3.5.0.tgz#87bf40292b8cf83e4e8ce1a3ae4209e20071675a"
 
 lodash.isarguments@^3.0.0:
   version "3.1.0"
@@ -2888,6 +2902,10 @@ lodash.some@^4.2.2:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
 
+lodash.sortby@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
+
 lodash.template@^3.0.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-3.6.2.tgz#f8cdecc6169a255be9098ae8b0c53d378931d14f"
@@ -2917,7 +2935,7 @@ lodash.uniqby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
 
-lodash@^4.0.0, lodash@^4.14.0, lodash@^4.2.0, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.11.1, lodash@^4.14.0, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 


### PR DESCRIPTION
* algorithm which tries to order the rows/columns of the DSM to lower left shape as far as possible
* mark strongly connected nodes, i.e. nodes which can reach every other node in the set and vice versa

TODO:
* [ ] refactor code
* [ ] replace custom cycle calculation with usage of `graphlib` and print them on web page